### PR TITLE
feat: Add configurable activation limit for schedule segments

### DIFF
--- a/ScheduleAlgorithm.cs
+++ b/ScheduleAlgorithm.cs
@@ -52,7 +52,7 @@ internal static class ScheduleAlgorithm
             if (allEntries.Count == 0) return (null, "No schedule generated");
             // Select comfort hours: price below percentile threshold
             var sorted = allEntries.OrderBy(e => e.value).ToList();
-            int maxActivationsPerDay = activationLimit; // was 4, increased default to 6
+            int maxActivationsPerDay = activationLimit;
             var percentileIdx = (int)Math.Floor(allEntries.Count * 0.2); // 20th percentile
             var priceThreshold = sorted[Math.Max(0, percentileIdx)].value;
             var comfortCandidates = allEntries.Where(e => e.value <= priceThreshold).OrderBy(e => e.start).ToList();


### PR DESCRIPTION
This pull request introduces a configurable limit for the maximum number of daily activations in the schedule algorithm, replacing the previous hardcoded value. The changes ensure that both schedule generation and segment insertion/removal logic consistently respect this new limit, allowing for more flexible scheduling based on configuration.

**Configurable activation limit:**

* Added `Schedule:MaxActivationsPerDay` to configuration, parsed as `activationLimit` (default 6, previously hardcoded as 4). (`ScheduleAlgorithm.cs`)
* Updated the comfort hour selection logic to use the new `activationLimit` instead of the previous hardcoded value. (`ScheduleAlgorithm.cs`)

**Segment management logic:**

* Refactored segment insertion and removal logic in `AddDay` to use `activationLimit` for all checks, ensuring the number of segments does not exceed the configured maximum. (`ScheduleAlgorithm.cs`)