### PR TITLE
feat: Include all hours for today in schedule algorithm

### DIFF
--- a/ScheduleAlgorithm.cs
+++ b/ScheduleAlgorithm.cs
@@ -102,7 +102,7 @@ internal static class ScheduleAlgorithm
                 var valueStr = item["value"]?.ToString();
                 if (!DateTimeOffset.TryParse(startStr, out var startTs)) continue;
                 if (startTs.Date != date) continue;
-                if (date == now.Date && startTs.Hour < now.Hour) continue; // Skip hours before now for today
+                // Removed: if (date == now.Date && startTs.Hour < now.Hour) continue; // Now include all hours for today
                 if (!decimal.TryParse(valueStr, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var val)) continue;
                 entries.Add((startTs, val));
             }


### PR DESCRIPTION
This pull request makes a small change to the scheduling logic in `ScheduleAlgorithm.cs`. The update ensures that all time slots for the current day are now included, rather than skipping hours that have already passed.

* Scheduling logic update: Removed the condition that skipped hours earlier than the current hour for today, so all hours for the current date are now considered.