### PR TITLE
feat: Add auto-apply schedule feature with user settings integration

### DIFF
--- a/NordpoolPriceJob.cs
+++ b/NordpoolPriceJob.cs
@@ -116,7 +116,8 @@ internal class NordpoolPriceJob : IHostedService, IDisposable
             // Per-user auto-apply schedule
             if (Directory.Exists("tokens"))
             {
-                foreach (var userDir in Directory.GetDirectories("tokens"))
+                var userDirs = Directory.GetDirectories("tokens");
+                foreach (var userDir in userDirs)
                 {
                     try
                     {

--- a/NordpoolPriceJob.cs
+++ b/NordpoolPriceJob.cs
@@ -113,7 +113,7 @@ internal class NordpoolPriceJob : IHostedService, IDisposable
             }
         }
 
-            // Per-user auto-apply schedule
+                // Per-user auto-apply schedule
             if (Directory.Exists("tokens"))
             {
                 var userDirs = Directory.GetDirectories("tokens");

--- a/NordpoolPriceJob.cs
+++ b/NordpoolPriceJob.cs
@@ -124,7 +124,7 @@ internal class NordpoolPriceJob : IHostedService, IDisposable
                         var userId = Path.GetFileName(userDir);
                         var userJsonPath = Path.Combine(userDir, "user.json");
                         if (!File.Exists(userJsonPath)) continue;
-                        var json = File.ReadAllText(userJsonPath);
+                        var json = await File.ReadAllTextAsync(userJsonPath);
                         var node = JsonNode.Parse(json) as JsonObject;
                         if (node == null) continue;
                         bool autoApply = bool.TryParse(node["AutoApplySchedule"]?.ToString(), out var aas) ? aas : false;

--- a/Program.cs
+++ b/Program.cs
@@ -45,11 +45,13 @@ app.MapGet("/api/user/settings", async (HttpContext ctx) =>
     int comfortHours = int.TryParse(node?["ComfortHours"]?.ToString(), out var ch) ? ch : 3;
     double turnOffPercentile = double.TryParse(node?["TurnOffPercentile"]?.ToString(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var tp) ? tp : 0.9;
     int turnOffMaxConsecutive = int.TryParse(node?["TurnOffMaxConsecutive"]?.ToString(), out var tmc) ? tmc : 2;
+    bool autoApplySchedule = node?["AutoApplySchedule"] != null && bool.TryParse(node?["AutoApplySchedule"]?.ToString(), out var aas) ? aas : false;
     return Results.Json(new
     {
         ComfortHours = comfortHours,
         TurnOffPercentile = turnOffPercentile,
-        TurnOffMaxConsecutive = turnOffMaxConsecutive
+        TurnOffMaxConsecutive = turnOffMaxConsecutive,
+        AutoApplySchedule = autoApplySchedule
     });
 });
 
@@ -69,14 +71,17 @@ app.MapPost("/api/user/settings", async (HttpContext ctx) =>
     var rawCh = body["ComfortHours"]?.ToString();
     var rawTp = body["TurnOffPercentile"]?.ToString();
     var rawTmc = body["TurnOffMaxConsecutive"]?.ToString();
-    int ch; double tp; int tmc;
+    var rawAas = body["AutoApplySchedule"]?.ToString();
+    int ch; double tp; int tmc; bool aas;
     bool chOk = int.TryParse(rawCh, out ch);
     bool tpOk = double.TryParse(rawTp, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out tp);
     bool tmcOk = int.TryParse(rawTmc, out tmc);
-    Console.WriteLine($"[UserSettings] Received: ComfortHours={rawCh} (parsed={(chOk ? ch.ToString() : "fail")}), TurnOffPercentile={rawTp} (parsed={(tpOk ? tp.ToString() : "fail")}), TurnOffMaxConsecutive={rawTmc} (parsed={(tmcOk ? tmc.ToString() : "fail")})");
+    bool aasOk = bool.TryParse(rawAas, out aas);
+    Console.WriteLine($"[UserSettings] Received: ComfortHours={rawCh} (parsed={(chOk ? ch.ToString() : "fail")}), TurnOffPercentile={rawTp} (parsed={(tpOk ? tp.ToString() : "fail")}), TurnOffMaxConsecutive={rawTmc} (parsed={(tmcOk ? tmc.ToString() : "fail")}), AutoApplySchedule={rawAas} (parsed={(aasOk ? aas.ToString() : "fail")})");
     node["ComfortHours"] = chOk ? ch : 3;
     node["TurnOffPercentile"] = tpOk ? tp : 0.9;
     node["TurnOffMaxConsecutive"] = tmcOk ? tmc : 2;
+    node["AutoApplySchedule"] = aasOk ? aas : false;
     await File.WriteAllTextAsync(path, node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
     return Results.Ok(new { saved = true });
 });

--- a/Program.cs
+++ b/Program.cs
@@ -77,13 +77,13 @@ app.MapPost("/api/user/settings", async (HttpContext ctx) =>
     bool tpOk = double.TryParse(rawTp, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out tp);
     bool tmcOk = int.TryParse(rawTmc, out tmc);
     bool aasOk = bool.TryParse(rawAas, out aas);
-    Console.WriteLine(JsonSerializer.Serialize(new {
-        Event = "UserSettingsReceived",
-        ComfortHours = new { Raw = rawCh, Parsed = chOk ? ch : "fail" },
-        TurnOffPercentile = new { Raw = rawTp, Parsed = tpOk ? tp : "fail" },
-        TurnOffMaxConsecutive = new { Raw = rawTmc, Parsed = tmcOk ? tmc : "fail" },
-        AutoApplySchedule = new { Raw = rawAas, Parsed = aasOk ? aas : "fail" }
-    }, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine(
+        $"Event: UserSettingsReceived\n" +
+        $"  ComfortHours: Raw={rawCh}, Parsed={(chOk ? ch : "fail")}\n" +
+        $"  TurnOffPercentile: Raw={rawTp}, Parsed={(tpOk ? tp : "fail")}\n" +
+        $"  TurnOffMaxConsecutive: Raw={rawTmc}, Parsed={(tmcOk ? tmc : "fail")}\n" +
+        $"  AutoApplySchedule: Raw={rawAas}, Parsed={(aasOk ? aas : "fail")}"
+    );
     node["ComfortHours"] = chOk ? ch : 3;
     node["TurnOffPercentile"] = tpOk ? tp : 0.9;
     node["TurnOffMaxConsecutive"] = tmcOk ? tmc : 2;

--- a/Program.cs
+++ b/Program.cs
@@ -77,7 +77,13 @@ app.MapPost("/api/user/settings", async (HttpContext ctx) =>
     bool tpOk = double.TryParse(rawTp, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out tp);
     bool tmcOk = int.TryParse(rawTmc, out tmc);
     bool aasOk = bool.TryParse(rawAas, out aas);
-    Console.WriteLine($"[UserSettings] Received: ComfortHours={rawCh} (parsed={(chOk ? ch.ToString() : "fail")}), TurnOffPercentile={rawTp} (parsed={(tpOk ? tp.ToString() : "fail")}), TurnOffMaxConsecutive={rawTmc} (parsed={(tmcOk ? tmc.ToString() : "fail")}), AutoApplySchedule={rawAas} (parsed={(aasOk ? aas.ToString() : "fail")})");
+    Console.WriteLine(JsonSerializer.Serialize(new {
+        Event = "UserSettingsReceived",
+        ComfortHours = new { Raw = rawCh, Parsed = chOk ? ch : "fail" },
+        TurnOffPercentile = new { Raw = rawTp, Parsed = tpOk ? tp : "fail" },
+        TurnOffMaxConsecutive = new { Raw = rawTmc, Parsed = tmcOk ? tmc : "fail" },
+        AutoApplySchedule = new { Raw = rawAas, Parsed = aasOk ? aas : "fail" }
+    }, new JsonSerializerOptions { WriteIndented = true }));
     node["ComfortHours"] = chOk ? ch : 3;
     node["TurnOffPercentile"] = tpOk ? tp : 0.9;
     node["TurnOffMaxConsecutive"] = tmcOk ? tmc : 2;

--- a/Program.cs
+++ b/Program.cs
@@ -45,7 +45,7 @@ app.MapGet("/api/user/settings", async (HttpContext ctx) =>
     int comfortHours = int.TryParse(node?["ComfortHours"]?.ToString(), out var ch) ? ch : 3;
     double turnOffPercentile = double.TryParse(node?["TurnOffPercentile"]?.ToString(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var tp) ? tp : 0.9;
     int turnOffMaxConsecutive = int.TryParse(node?["TurnOffMaxConsecutive"]?.ToString(), out var tmc) ? tmc : 2;
-    bool autoApplySchedule = node?["AutoApplySchedule"] != null && bool.TryParse(node?["AutoApplySchedule"]?.ToString(), out var aas) ? aas : false;
+    bool autoApplySchedule = bool.TryParse(node?["AutoApplySchedule"]?.ToString(), out var aas) ? aas : false;
     return Results.Json(new
     {
         ComfortHours = comfortHours,

--- a/wwwroot/settings.html
+++ b/wwwroot/settings.html
@@ -21,6 +21,11 @@
         </h3>
         <div class="settings-card" style="background:#f7f7fa;border-radius:10px;padding:1.5rem 1.5rem 1rem 1.5rem;box-shadow:0 2px 8px rgba(25,118,210,0.08);margin-bottom:1.5rem;">
           <div class="settings-row" style="margin-bottom:1.2rem;">
+          <div class="settings-row" style="margin-bottom:1.2rem;">
+            <label for="autoApplySchedule" style="min-width:140px;">Auto-apply schedule</label>
+            <input id="autoApplySchedule" type="checkbox" value="1" title="Automatically apply schedule in the background">
+            <span class="tooltip" style="margin-left:12px;">Automatically apply the generated schedule in the background (recommended only if you want hands-off operation).</span>
+          </div>
             <label for="zoneSelect" style="min-width:140px;">Zone</label>
             <select id="zoneSelect" style="min-width:120px;">
               <option value="SE3">SE3</option>

--- a/wwwroot/settings.html
+++ b/wwwroot/settings.html
@@ -21,11 +21,11 @@
         </h3>
         <div class="settings-card" style="background:#f7f7fa;border-radius:10px;padding:1.5rem 1.5rem 1rem 1.5rem;box-shadow:0 2px 8px rgba(25,118,210,0.08);margin-bottom:1.5rem;">
           <div class="settings-row" style="margin-bottom:1.2rem;">
-          <div class="settings-row" style="margin-bottom:1.2rem;">
             <label for="autoApplySchedule" style="min-width:140px;">Auto-apply schedule</label>
             <input id="autoApplySchedule" type="checkbox" value="1" title="Automatically apply schedule in the background">
             <span class="tooltip" style="margin-left:12px;">Automatically apply the generated schedule in the background (recommended only if you want hands-off operation).</span>
           </div>
+          <div class="settings-row" style="margin-bottom:1.2rem;">
             <label for="zoneSelect" style="min-width:140px;">Zone</label>
             <select id="zoneSelect" style="min-width:120px;">
               <option value="SE3">SE3</option>

--- a/wwwroot/ui.js
+++ b/wwwroot/ui.js
@@ -144,6 +144,7 @@ const comfortHoursEl = document.getElementById('comfortHours');
 if(comfortHoursEl){
   const turnOffPercentileEl = document.getElementById('turnOffPercentile');
   const turnOffMaxConsecutiveEl = document.getElementById('turnOffMaxConsecutive');
+  const autoApplyScheduleEl = document.getElementById('autoApplySchedule');
   const saveUserSettingsBtn = document.getElementById('saveUserSettings');
   const userSettingsStatus = document.getElementById('userSettingsStatus');
 
@@ -152,9 +153,10 @@ if(comfortHoursEl){
       const res = await fetch('/api/user/settings');
       if(!res.ok) throw new Error('Could not load settings');
       const d = await res.json();
-  comfortHoursEl.value = d.comfortHours ?? 3;
-  if(turnOffPercentileEl) turnOffPercentileEl.value = d.turnOffPercentile ?? 0.9;
-  if(turnOffMaxConsecutiveEl) turnOffMaxConsecutiveEl.value = d.turnOffMaxConsecutive ?? 2;
+      comfortHoursEl.value = d.comfortHours ?? 3;
+      if(turnOffPercentileEl) turnOffPercentileEl.value = d.turnOffPercentile ?? 0.9;
+      if(turnOffMaxConsecutiveEl) turnOffMaxConsecutiveEl.value = d.turnOffMaxConsecutive ?? 2;
+      if(autoApplyScheduleEl) autoApplyScheduleEl.checked = !!d.autoApplySchedule;
       if(userSettingsStatus) userSettingsStatus.textContent = '';
     } catch(e) { if(userSettingsStatus) userSettingsStatus.textContent = 'Error: ' + e.message; }
   })();
@@ -165,7 +167,8 @@ if(comfortHoursEl){
       const body = {
         ComfortHours: comfortHoursEl.value || 3,
         TurnOffPercentile: turnOffPercentileEl?.value || 0.9,
-        TurnOffMaxConsecutive: turnOffMaxConsecutiveEl?.value || 2
+        TurnOffMaxConsecutive: turnOffMaxConsecutiveEl?.value || 2,
+        AutoApplySchedule: autoApplyScheduleEl?.checked || false
       };
       const res = await fetch('/api/user/settings', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
       if(!res.ok) throw new Error(await res.text());


### PR DESCRIPTION
This pull request adds a new "Auto-apply schedule" feature, allowing users to automatically apply their generated schedule in the background. The implementation includes backend, frontend, and job logic changes to support saving, displaying, and acting on this setting.

**Auto-apply schedule feature**

* Added a new checkbox for "Auto-apply schedule" in the user settings UI (`settings.html`), with supporting tooltip and integration in the frontend logic to load and save the setting (`ui.js`). [[1]](diffhunk://#diff-b1a458510c4262e354b3618da8a518cbbd5009e93ce1147be95274739693e979R24-R28) [[2]](diffhunk://#diff-a3c15b197fe94fb9689c3c6923368be28491009592f31bc1cac0d288be858cf5R147) [[3]](diffhunk://#diff-a3c15b197fe94fb9689c3c6923368be28491009592f31bc1cac0d288be858cf5R159) [[4]](diffhunk://#diff-a3c15b197fe94fb9689c3c6923368be28491009592f31bc1cac0d288be858cf5L168-R171)
* Updated backend endpoints to handle the new `AutoApplySchedule` field: it is now included in user settings retrieval, saved when posted, and properly parsed and persisted (`Program.cs`). [[1]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bR48-R54) [[2]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bL72-R84)

**Background job logic**

* Enhanced the `NordpoolPriceJob` to scan user tokens and automatically apply schedules for users who have enabled "Auto-apply schedule", with error handling and logging for each user processed (`NordpoolPriceJob.cs`).