### PR TITLE
fix: force 24h time format for Nordic locales

### DIFF
--- a/frontend/src/context/TimezoneContext.tsx
+++ b/frontend/src/context/TimezoneContext.tsx
@@ -217,11 +217,11 @@ export function useLocale() {
 
 export function useFormatters() {
   const { timezone } = useTimezone();
-  const { locale } = useLocale();
+  const { effectiveLocale } = useLocale();
 
   return useMemo(() => ({
-    formatDateTime: (date: Date | string | number) => rawFormatDateTime(date, timezone, locale),
-    formatTime: (date: Date | string | number) => rawFormatTime(date, timezone, locale),
-    formatDateTimeFull: (date: Date | string | number) => rawFormatDateTimeFull(date, timezone, locale),
-  }), [timezone, locale]);
+    formatDateTime: (date: Date | string | number) => rawFormatDateTime(date, timezone, effectiveLocale),
+    formatTime: (date: Date | string | number) => rawFormatTime(date, timezone, effectiveLocale),
+    formatDateTimeFull: (date: Date | string | number) => rawFormatDateTimeFull(date, timezone, effectiveLocale),
+  }), [timezone, effectiveLocale]);
 }

--- a/frontend/src/dateFormat.ts
+++ b/frontend/src/dateFormat.ts
@@ -8,8 +8,20 @@ function resolveTimeZone(timeZone?: string): string | undefined {
   return timeZone && timeZone !== 'auto' ? timeZone : undefined;
 }
 
+/** Locales that conventionally use 24-hour time. */
+const HOUR24_LOCALES = ['sv-SE', 'nb-NO', 'da-DK', 'fi-FI', 'sv', 'nb', 'da', 'fi'];
+
 function resolveLocale(locale?: string): string | undefined {
   return locale && locale !== 'auto' ? locale : undefined;
+}
+
+/** Returns hourCycle override when the locale uses 24h time, to prevent OS-level 12h overrides. */
+function resolveHourCycle(locale?: string): { hourCycle: 'h23' } | {} {
+  const resolved = resolveLocale(locale);
+  if (resolved && HOUR24_LOCALES.some(l => resolved.startsWith(l))) {
+    return { hourCycle: 'h23' as const };
+  }
+  return {};
 }
 
 /** Full date + time, e.g. "2026-03-09 14:30" or "3/9/2026, 2:30 PM" depending on locale */
@@ -22,6 +34,7 @@ export function formatDateTime(date: Date | string | number, timeZone?: string, 
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
+    ...resolveHourCycle(locale),
   });
 }
 
@@ -32,6 +45,7 @@ export function formatTime(date: Date | string | number, timeZone?: string, loca
     timeZone: resolveTimeZone(timeZone),
     hour: '2-digit',
     minute: '2-digit',
+    ...resolveHourCycle(locale),
   });
 }
 
@@ -46,5 +60,6 @@ export function formatDateTimeFull(date: Date | string | number, timeZone?: stri
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
+    ...resolveHourCycle(locale),
   });
 }

--- a/frontend/src/dateFormat.ts
+++ b/frontend/src/dateFormat.ts
@@ -9,8 +9,20 @@ function resolveTimeZone(timeZone?: string): string | undefined {
 }
 
 /** Locales that conventionally use 24-hour time. */
-const HOUR24_LOCALES = ['sv-SE', 'nb-NO', 'da-DK', 'fi-FI', 'sv', 'nb', 'da', 'fi'];
-
+const HOUR24_LOCALES = [
+  'sv-SE',
+  'nb-NO',
+  'no-NO',
+  'nn-NO',
+  'da-DK',
+  'fi-FI',
+  'sv',
+  'nb',
+  'no',
+  'nn',
+  'da',
+  'fi',
+];
 function resolveLocale(locale?: string): string | undefined {
   return locale && locale !== 'auto' ? locale : undefined;
 }

--- a/frontend/src/dateFormat.ts
+++ b/frontend/src/dateFormat.ts
@@ -18,9 +18,25 @@ function resolveLocale(locale?: string): string | undefined {
 /** Returns hourCycle override when the locale uses 24h time, to prevent OS-level 12h overrides. */
 function resolveHourCycle(locale?: string): { hourCycle: 'h23' } | {} {
   const resolved = resolveLocale(locale);
-  if (resolved && HOUR24_LOCALES.some(l => resolved.startsWith(l))) {
+  if (!resolved) {
+    return {};
+  }
+
+  const primaryLanguage = resolved.split('-')[0];
+
+  const uses24h = HOUR24_LOCALES.some(l => {
+    // Full locale tag (e.g. "sv-SE") – match exact tag or that tag with extra subtags.
+    if (l.includes('-')) {
+      return resolved === l || resolved.startsWith(`${l}-`);
+    }
+    // Language-only tag (e.g. "sv", "fi") – match primary language subtag exactly.
+    return primaryLanguage === l;
+  });
+
+  if (uses24h) {
     return { hourCycle: 'h23' as const };
   }
+
   return {};
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,8 +30,6 @@ export default defineConfig({
           'react-vendor': ['react', 'react-dom', 'react-router-dom'],
           // Split React Query
           'query': ['@tanstack/react-query'],
-          // Split date utilities
-          'date-utils': ['date-fns'],
         },
       },
     },


### PR DESCRIPTION
## Problem
All timestamps in the GUI show 12h AM/PM format even when the user locale is set to Swedish (sv-SE) which conventionally uses 24h format.

## Root Cause
1. useFormatters() passed locale (undefined in Auto mode) instead of effectiveLocale (concrete string like sv-SE). When undefined was passed to toLocaleString(), some browser/OS combinations fell back to 12h format.
2. No explicit hourCycle override - even with sv-SE locale, some browsers can still use 12h format based on OS-level regional settings.
3. Build was broken - date-fns was listed in Vite manualChunks but never imported, causing an empty chunk error on npm run build.

## Fix
- Use effectiveLocale (always a concrete locale string) in useFormatters() instead of locale
- Add hourCycle h23 override for Nordic locales (sv-SE, nb-NO, da-DK, fi-FI) to force 24h format
- Remove unused date-fns from Vite manualChunks configuration

## Verification
- Frontend builds successfully (npm run build)
- All 416 backend tests pass
- Bundle output verified to contain hourCycle h23 logic